### PR TITLE
Update brew.js with link function

### DIFF
--- a/brew.js
+++ b/brew.js
@@ -30,6 +30,13 @@ export const run = async () => {
         grpEnd(msSt)
         brew = brew.replace(/\b_upgrade_\b/gi, '').trim()
       }
+      
+      if (/\b_link_\b/.test(brew)) {
+        msSt = grpSt('brew link')
+        execSync('brew link')
+        grpEnd(msSt)
+        brew = brew.replace(/\b_link_\b/gi, '').trim()
+      }
 
       if (brew !== '') {
         msSt = grpSt(`brew install ${brew}`)


### PR DESCRIPTION
Hello I am running this action on a project but because Mac has sqlite3 preinstalled it fails the tests. I have tried with the --force option and it gave me this output:   

Warning: sqlite 3.31.1 is already installed, it's just not linked
You can use `brew link sqlite` to link this version.

I believe that with adding the brew link functionality that this will fix my failing tests.