### PR TITLE
Add `setup-ruby-ref` to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
   vcpkg:
     description: 'mswin - install vcpkg packages'
     default: ''
+  setup-ruby-ref:
+    description: 'Base ruby-setup repository. It is executed before installing packages.'
+    default: 'ruby/setup-ruby/v1'
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
This fixes this github action warning:
```
Unexpected input(s) 'setup-ruby-ref', valid inputs are ['ruby-version', 'bundler', 'bundler-cache', 'working-directory', 'apt-get', 'brew', 'mingw', 'msys2', 'mswin', 'choco', 'vcpkg']
```

This might be merged to master branch as well.